### PR TITLE
Removing securemock depedency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,6 @@ configurations.all {
 
 configurations {
     testCompile {
-        exclude group: 'org.elasticsearch', module: 'securemock'
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 }


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

Removing securemock for AD.